### PR TITLE
Fixes issue with React testing library version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@nordhealth/css": "*",
     "@nordhealth/react": "*",
     "@testing-library/jest-dom": "^5.16.2",
-    "@testing-library/react": "^12.1.3",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^27.4.1",
     "@types/node": "^16.11.26",

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -7,7 +7,7 @@ import type { Input as InputType } from "@nordhealth/components";
 function useField(name: string, initialValue = "") {
   const [value, setValue] = useState(initialValue);
   const [error, setError] = useState<string>();
-  const ref = useRef<InputType>();
+  const ref = useRef<InputType>(null);
   const valid = Boolean(value);
 
   useEffect(() => {


### PR DESCRIPTION
- Fixes an issue where `@testing-library/react` had a dependency to older version of react making `npm install` break.
- Additionally fixes TS errors when updating `@nordhealth/components` and `@nordhealth/react`version to 3.0.0.
  - The above may be a sign that we have a bug in the React specific configuration in Nord. 
  - Needs more investigation before merge to see if we can avoid this issue already on the system level.